### PR TITLE
Bug Fix init

### DIFF
--- a/glmocr/__init__.py
+++ b/glmocr/__init__.py
@@ -1,27 +1,12 @@
-"""GlmOcr - Document Parsing with GLM OCR.
+"""GLM-OCR Python SDK.  """
 
-Document parsing service that supports layout detection and text recognition.
+from __future__ import annotations
 
-Supports two modes:
-1. MaaS Mode: Passthrough to Zhipu cloud API (no GPU required)
-2. Self-hosted Mode: Local vLLM/SGLang deployment (GPU required)
-"""
+import importlib
+from typing import TYPE_CHECKING
 
 __version__ = "0.1.1"
 __author__ = "ZHIPUAI"
-
-# Import main components
-from . import dataloader
-from . import layout
-from . import postprocess
-from . import utils
-from .pipeline import Pipeline
-from .config import GlmOcrConfig, load_config
-from .parser_result import PipelineResult
-from .maas_client import MaaSClient
-
-# Import API
-from .api import GlmOcr, parse
 
 __all__ = [
     "dataloader",
@@ -36,3 +21,41 @@ __all__ = [
     "GlmOcr",
     "parse",
 ]
+
+
+_LAZY_SUBMODULES = {"dataloader", "layout", "postprocess", "utils"}
+_LAZY_ATTRS = {
+    "Pipeline": ("pipeline", "Pipeline"),
+    "PipelineResult": ("parser_result", "PipelineResult"),
+    "GlmOcrConfig": ("config", "GlmOcrConfig"),
+    "load_config": ("config", "load_config"),
+    "MaaSClient": ("maas_client", "MaaSClient"),
+    "GlmOcr": ("api", "GlmOcr"),
+    "parse": ("api", "parse"),
+}
+
+
+def __getattr__(name: str):
+    if name in _LAZY_SUBMODULES:
+        return importlib.import_module(f"{__name__}.{name}")
+
+    target = _LAZY_ATTRS.get(name)
+    if target is None:
+        raise AttributeError(f"module '{__name__}' has no attribute '{name}'")
+
+    module_name, attr_name = target
+    module = importlib.import_module(f"{__name__}.{module_name}")
+    return getattr(module, attr_name)
+
+
+def __dir__():
+    return sorted(list(globals().keys()) + list(__all__))
+
+
+if TYPE_CHECKING:  # pragma: no cover
+    from . import dataloader, layout, postprocess, utils
+    from .api import GlmOcr, parse
+    from .config import GlmOcrConfig, load_config
+    from .maas_client import MaaSClient
+    from .parser_result import PipelineResult
+    from .pipeline import Pipeline


### PR DESCRIPTION
This PR intentionally avoids eager imports in ``__init__``.

Some users import symbols like ``from glmocr import dataloader`` in environments
where optional dependencies are missing or where import order differs.
Eagerly importing heavy submodules (pipeline/layout/api) can then lead to
"partially initialized module" ImportError due to circular import chains.

We keep the public API stable via lazy imports (PEP 562).