### PR TITLE
feat: use portalocker for file locks on all platforms

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
   "pydantic>=2.7.0",
   "wordfreq>=3.0.0",
   "PyYAML>=6.0.0",
+  "portalocker>=2.8.2",
 
   # Layout detection
   "torch>=2.0.0",


### PR DESCRIPTION
This PR replaces the Unix-only fcntl lock with portalocker to enable cross-platform file locking.
It also adds portalocker to project dependencies to ensure the lock utilities work on Windows and Linux.
