### PR TITLE
fix: Align line-length configuration between pyproject.toml and pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,13 +20,13 @@ repos:
     hooks:
       - id: black
         language_version: python3
-        args: ["--line-length=88"]
+        args: ["--line-length=100"]
 
   - repo: https://github.com/pycqa/flake8
     rev: 7.0.0
     hooks:
       - id: flake8
-        args: ["--max-line-length=88", "--extend-ignore=E203,W503,E501"]
+        args: ["--max-line-length=100", "--extend-ignore=E203,W503,E501"]
 
   - repo: https://github.com/crate-ci/typos
     rev: v1.16.26


### PR DESCRIPTION
## Summary

Fix configuration inconsistency between `pyproject.toml` and `.pre-commit-config.yaml` regarding line length limits.

## Problem

The black formatter was configured with `line-length=100` in `pyproject.toml`, but the pre-commit hooks were using `--line-length=88`. This inconsistency causes several issues:

1. **Inconsistent formatting**: Code formatted via pre-commit (`black --line-length=88`) would differ from code formatted directly with black (which reads `line-length=100` from pyproject.toml)
2. **CI/CD failures**: Builds could fail if CI uses different formatting configuration than local pre-commit hooks
3. **Developer confusion**: Unclear which line length limit (88 or 100) is the actual project standard

## Solution

Update `.pre-commit-config.yaml` to use `line-length=100` for both black and flake8, matching the `pyproject.toml` configuration.

### Changes Made

```diff
# .pre-commit-config.yaml
- args: ["--line-length=88"]   # black
+ args: ["--line-length=100"]  # black

- args: ["--max-line-length=88", "--extend-ignore=E203,W503,E501"]  # flake8
+ args: ["--max-line-length=100", "--extend-ignore=E203,W503,E501"]  # flake8
```

## Impact

- **Low risk**: This only aligns existing configuration; no code formatting changes are included in this PR
- **Improves consistency**: Ensures all tooling uses the same 100-character line limit
- **Prevents future issues**: Developers won't encounter formatting mismatches between local and CI environments

## Test plan

This is a configuration-only fix with no code changes. The change ensures:
- Pre-commit hooks now respect the same 100-character limit defined in pyproject.toml
- Running `black .` locally will produce the same results as pre-commit
- Existing code remains unchanged (no reformatting included in this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)