### PR TITLE
remove ollama serve from recommended steps to avoid service conflicts

### DIFF
--- a/examples/ollama-deploy/README.md
+++ b/examples/ollama-deploy/README.md
@@ -34,15 +34,6 @@ ollama pull glm-ocr:latest
 
 This will download the GLM-OCR model.
 
-### 4. Start Ollama Service
-
-The Ollama service should start automatically after installation. If not:
-
-```bash
-ollama serve
-```
-
-The service will run on `http://localhost:11434` by default.
 
 ## Configuration
 


### PR DESCRIPTION
This PR removes ollama serve from the recommended setup instructions.

When Ollama is installed via install.sh, a systemd service is created that already runs ollama serve under the dedicated ollama user. Manually running ollama serve can start a second instance, causing port conflicts and runtime state issues.

Additionally, running it as a different user can create permission mismatches (models, GPU access, PID files), leading to inconsistent behavior between the manual process and the systemd-managed service.

To avoid dual-instance conflicts and user/permission inconsistencies, users should rely on the systemd service instead of manually invoking ollama serve.