### PR TITLE
Make layout deps optional, fix requires-python, lazy-import cv2

### DIFF
--- a/glmocr/pipeline/pipeline.py
+++ b/glmocr/pipeline/pipeline.py
@@ -247,7 +247,16 @@ class Pipeline:
                 user_msg["content"].append(
                     {"type": "image_url", "image_url": {"url": data_url}}
                 )
-                per_request = self.page_loader.build_request(per_request)
+                # Set default parameters without calling build_request(),
+                # which would re-process the already-encoded image through
+                # load_image_to_base64 a second time.
+                per_request.setdefault("max_tokens", self.page_loader.max_tokens)
+                per_request.setdefault("temperature", self.page_loader.temperature)
+                per_request.setdefault("top_p", self.page_loader.top_p)
+                per_request.setdefault("top_k", self.page_loader.top_k)
+                per_request.setdefault(
+                    "repetition_penalty", self.page_loader.repetition_penalty
+                )
                 response, status_code = self.ocr_client.process(per_request)
                 if status_code != 200:
                     raise Exception(

--- a/glmocr/utils/__init__.py
+++ b/glmocr/utils/__init__.py
@@ -12,16 +12,22 @@ from .logging import (
     configure_logging,
     set_log_level,
 )
-from .visualization_utils import (
-    draw_layout_boxes,
-    save_layout_visualization,
-    get_colormap,
-)
 from .result_postprocess_utils import (
     find_consecutive_repeat,
     clean_repeated_content,
     clean_formula_number,
 )
+
+
+def __getattr__(name):
+    # Lazy imports for layout-only symbols that require opencv-python.
+    _viz_names = {"draw_layout_boxes", "save_layout_visualization", "get_colormap"}
+    if name in _viz_names:
+        from . import visualization_utils
+
+        return getattr(visualization_utils, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 __all__ = [
     "smart_resize",

--- a/glmocr/utils/image_utils.py
+++ b/glmocr/utils/image_utils.py
@@ -1,7 +1,6 @@
 """Image processing utilities."""
 
 import io
-import cv2
 import base64
 import math
 from io import BytesIO
@@ -191,6 +190,7 @@ def crop_image_region(image, bbox_2d, polygon=None, fill_color=255):
     Returns:
         PIL.Image.Image: Cropped region with optional polygon mask applied
     """
+    import cv2
     image_width, image_height = image.size
 
     # De-normalize bbox to pixel coordinates

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
   {name = "ZHIPUAI", email = "info@zhipuai.cn"}
 ]
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 license = {text = "Apache-2.0"}
 keywords = ["ocr", "glm", "ai", "vision"]
 classifiers = [
@@ -18,10 +18,10 @@ classifiers = [
   "Intended Audience :: Developers",
   "License :: OSI Approved :: Apache Software License",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.8",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
 ]
 
 dependencies = [
@@ -34,19 +34,8 @@ dependencies = [
   "portalocker>=2.8.2",
   "python-dotenv>=0.21.0",
 
-  # Layout detection
-  "torch>=2.0.0",
-  "torchvision>=0.15.0",
-  "transformers>=5.1.0",
-  "sentencepiece>=0.1.99",
-  "accelerate>=0.20.0",
-  "opencv-python>=4.8.0",
-
   # PDF support
   "pypdfium2>=5.3.0",
-
-  # Flask server
-  "flask>=2.3.0",
 ]
 
 [project.optional-dependencies]
@@ -68,14 +57,7 @@ server = [
 ]
 
 all = [
-  "torch>=2.0.0",
-  "torchvision>=0.15.0",
-  "transformers>=4.30.0",
-  "sentencepiece>=0.1.99",
-  "accelerate>=0.20.0",
-  "opencv-python>=4.8.0",
-  "pdf2image>=1.16.0",
-  "flask>=2.3.0",
+  "glmocr[layout,server]",
 ]
 dev = [
   "pytest>=7.0.0",
@@ -100,7 +82,7 @@ include = ["glmocr*"]
 
 [tool.black]
 line-length = 100
-target-version = ["py38", "py39", "py310", "py311"]
+target-version = ["py310", "py311", "py312", "py313"]
 
 [tool.pytest.ini_options]
 testpaths = ["glmocr/tests"]


### PR DESCRIPTION
## Summary

- **Move heavy deps to optional extras**: torch, torchvision, transformers, sentencepiece, accelerate, opencv-python, and flask are moved from core `dependencies` to their existing `[layout]` and `[server]` optional extras. OCR-only mode (`pip install glmocr`) now installs in seconds instead of pulling ~5GB of ML frameworks. Users who need layout detection install with `pip install glmocr[layout]` or `pip install glmocr[all]`.

- **Fix `requires-python`**: Bumped from `>=3.8` to `>=3.10`. The core dependency `transformers>=5.1.0` already requires Python 3.10+, so the old lower bound caused dependency resolver failures (e.g., `uv` cannot find a valid solution when it tries to satisfy `transformers>=5.1.0` across Python 3.8/3.9).

- **Lazy-import `cv2`**: Moved `import cv2` from module level in `image_utils.py` into `crop_image_region()`, and deferred `visualization_utils` imports in `utils/__init__.py` via `__getattr__`. `opencv-python` is only needed for layout detection (polygon cropping and visualization), but the module-level import made it a hard requirement even in OCR-only mode.

- **Fix double image preprocessing in pipeline**: In the OCR-only path of `Pipeline.process()`, images were encoded via `load_image_to_base64` (with `smart_resize`), then `build_request()` decoded and re-encoded them through `load_image_to_base64` a second time. Replaced the `build_request()` call with direct `setdefault()` for generation parameters.

- **Simplify `[all]` extra**: Changed from duplicating the full dependency list to referencing `glmocr[layout,server]`.

## Motivation

When using `glm-ocr` in OCR-only mode with an external inference server (e.g., mlx-vlm on Apple Silicon, vLLM, or the MaaS API), there's no need for torch, torchvision, or opencv. The current `pyproject.toml` makes these mandatory, which means a multi-GB install for a use case that only needs `requests` and `Pillow`.

The `requires-python >= 3.8` also blocks modern Python package managers (`uv`) from resolving dependencies, since `transformers >= 5.1.0` dropped Python 3.8/3.9 support.

## Test plan

- [ ] `pip install .` (or `uv sync`) installs without torch/opencv
- [ ] `pip install ".[layout]"` installs the full layout detection stack
- [ ] `pip install ".[all]"` installs everything
- [ ] OCR-only pipeline works without opencv installed
- [ ] Layout pipeline works with `[layout]` extra installed
- [ ] `from glmocr.utils import crop_image_region` succeeds without opencv (cv2 only imported when function is called)

🤖 Generated with [Claude Code](https://claude.com/claude-code)