### PR TITLE
Fix duplicate file paths in load_image_paths on case-insensitive filesystems

### DIFF
--- a/glmocr/cli.py
+++ b/glmocr/cli.py
@@ -42,7 +42,7 @@ def load_image_paths(input_path: str) -> List[str]:
         for ext in ["*.jpg", "*.jpeg", "*.png", "*.bmp", "*.gif", "*.webp", "*.pdf"]:
             image_paths.extend([str(p.absolute()) for p in path.glob(ext)])
             image_paths.extend([str(p.absolute()) for p in path.glob(ext.upper())])
-        image_paths.sort()
+        image_paths = sorted(set(image_paths))  # deduplicate
         if not image_paths:
             raise ValueError(
                 f"Cannot find image or PDF files in directory: {input_path}"


### PR DESCRIPTION
On case-insensitive filesystems (Windows NTFS, macOS HFS+), `path.glob("*.jpg")` and `path.glob("*.JPG")` both match the same files, causing every file to be added twice. This results in double the expected file count (e.g., 15912 instead of 7956).

Solution:
Deduplicate paths using set() before sorting. This preserves cross-platform compatibility — the uppercase glob is still needed for case-sensitive filesystems (Linux), while the deduplication handles case-insensitive ones.