### PR TITLE
[Bug fix] Sanitize output directory and file names for Windows compatibility

### DIFF
--- a/glmocr/parser_result/base.py
+++ b/glmocr/parser_result/base.py
@@ -6,6 +6,7 @@ Defines common fields and JSON/Markdown save logic.
 from __future__ import annotations
 
 import json
+import re
 import traceback
 from abc import ABC, abstractmethod
 from pathlib import Path
@@ -63,7 +64,8 @@ class BaseParserResult(ABC):
         output_dir = Path(output_dir).absolute()
         if self.original_images:
             image_path = Path(self.original_images[0])
-            output_path = output_dir / image_path.stem
+            base_name = self._sanitize_name(image_path.stem)
+            output_path = output_dir / base_name
         else:
             output_path = output_dir / "result"
 
@@ -126,6 +128,18 @@ class BaseParserResult(ABC):
             if val is not None:
                 d[attr.lstrip("_")] = val
         return d
+
+    @staticmethod
+    def _sanitize_name(value: str) -> str:
+        """Sanitize a string for use as a directory/file name.
+
+        Strips characters that are illegal on Windows (<>:"/\\|?*) and
+        control characters (0x00-0x1F).  Also removes trailing spaces
+        and dots which Windows silently drops, causing path mismatches.
+        """
+        value = re.sub(r"[<>:\"/\\|?*\x00-\x1F]", "_", value)
+        value = value.rstrip(" .")
+        return value or "result"
 
     def to_json(self, **kwargs: Any) -> str:
         """Serialise the result to a JSON string.

--- a/glmocr/parser_result/pipeline_result.py
+++ b/glmocr/parser_result/pipeline_result.py
@@ -67,7 +67,7 @@ class PipelineResult(BaseParserResult):
             return
 
         if self.original_images:
-            stem = Path(self.original_images[0]).stem
+            stem = self._sanitize_name(Path(self.original_images[0]).stem)
             target_dir = Path(output_dir).absolute() / stem / "layout_vis"
         else:
             target_dir = Path(output_dir).absolute() / "result" / "layout_vis"
@@ -86,7 +86,11 @@ class PipelineResult(BaseParserResult):
             layout_files = sorted(temp_layout_path.glob("layout_page*.jpg"))
             layout_files.extend(sorted(temp_layout_path.glob("layout_page*.png")))
 
-        stem = Path(self.original_images[0]).stem if self.original_images else "result"
+        stem = (
+            self._sanitize_name(Path(self.original_images[0]).stem)
+            if self.original_images
+            else "result"
+        )
         for layout_file in layout_files:
             m = re.match(
                 r"layout_page(\d+)\.(jpg|png)$",


### PR DESCRIPTION
## Summary

Add `_sanitize_name()` static method to `BaseParserResult` that replaces Windows-illegal characters in output directory and file names. Apply it at all three locations where `original_images[0].stem` is used to construct filesystem paths.

Fixes #132 

## Problem

`save()` crashes on Windows when the source PDF filename contains characters illegal on Windows (`<>:"/\|?*`, control characters). This is common with academic PDFs whose filenames include DOI strings (e.g., `10.4402:cjce.454545455`). See #132 for full details.

## Changes

### `glmocr/parser_result/base.py`
- Add `import re`
- Add `_sanitize_name()` static method: replaces `<>:"/\|?*` and `0x00-0x1F` with `_`, strips trailing spaces/dots, falls back to `"result"` for empty strings
- Apply in `_save_json_and_markdown()` when constructing the output directory name

### `glmocr/parser_result/pipeline_result.py`
- Apply `_sanitize_name()` in `_save_layout_vis()` at both locations:
  - Target directory name (line 70)
  - Layout visualization filenames (line 89)

## Backward Compatibility

- On Linux/macOS, most of these characters are already legal — sanitization replaces only truly illegal ones, so existing output paths are unchanged for clean filenames
- The replacement character `_` is safe on all platforms
- Empty or whitespace-only stems fall back to `"result"` (same as the existing else-branch)

## Testing

- Tested `PipelineResult.save()` with 8 adversarial filenames on Windows 10: colons, angle brackets, pipes, question marks, double quotes, trailing dots, empty strings, and clean names
- multiple academic PDFs processed without `OSError`
- `pre-commit run --all-files` — all checks passed (black, flake8, typos, trailing whitespace, YAML, TOML)