### PR TITLE
[Bug fix] Handle numpy arrays in polygon_points visualization

### DIFF
--- a/glmocr/utils/visualization_utils.py
+++ b/glmocr/utils/visualization_utils.py
@@ -168,8 +168,8 @@ def _draw_polygon_masks(
     draw = ImageDraw.Draw(overlay)
 
     for i, box_info in enumerate(boxes):
-        polygon_points = box_info.get("polygon_points") or []
-        if len(polygon_points) < 3:
+        polygon_points = box_info.get("polygon_points")
+        if polygon_points is None or len(polygon_points) < 3:
             continue
 
         # Use the same color as label text
@@ -296,7 +296,7 @@ def draw_layout_boxes(
             draw.line(rectangle, width=draw_thickness, fill=color)
 
         # Determine text anchor position
-        if has_polygon and len(polygon_points) >= 3:
+        if has_polygon and polygon_points is not None and len(polygon_points) >= 3:
             # Find left-top and right-top points of polygon
             image_left_top = (0, 0)
             image_right_top = (img_width, 0)


### PR DESCRIPTION
## Summary

Fix `ValueError` crash in layout visualization when `polygon_points` are numpy arrays instead of Python lists.

Fixes #134 

## Problem

`_draw_polygon_masks()` uses `box_info.get("polygon_points") or []` which calls `bool()` on the result. When `polygon_points` is a numpy array (as returned by `PPDocLayoutV3`'s post-processing), this raises:

```
ValueError: The truth value of an array with more than one element is ambiguous
```

This crashes every `parse()` call with layout-enabled PDFs that produce polygon data, since `save_layout_visualization` defaults to `True`.

See #134  for full reproduction steps and stack trace.

## Changes

**File:** `glmocr/utils/visualization_utils.py` (2 lines changed)

### `_draw_polygon_masks()` — line 171

Replace the falsy-or pattern with an explicit `None` check:

```python
# Before:
polygon_points = box_info.get("polygon_points") or []
if len(polygon_points) < 3:

# After:
polygon_points = box_info.get("polygon_points")
if polygon_points is None or len(polygon_points) < 3:
```

`len()` works correctly on both numpy arrays and Python lists, so no further changes needed.

### `draw_layout_boxes()` — line 299

Add a `None` guard before `len()`:

```python
# Before:
if has_polygon and len(polygon_points) >= 3:

# After:
if has_polygon and polygon_points is not None and len(polygon_points) >= 3:
```

`has_polygon` is a global flag (True if *any* box has polygon data), but individual boxes may have `polygon_points=None`. Without the guard, `len(None)` raises `TypeError`.

## Testing

Tested with `save_layout_visualization=True` on a multi-page academic PDF:

| Scenario                        | Before fix         | After fix                                              |
| ------------------------------- | ------------------ | ------------------------------------------------------ |
| `save_layout_visualization=True`  | **CRASH** — `ValueError` | **PASS** — layout visualization images generated correctly |
| `save_layout_visualization=False` | PASS               | PASS                                                   |

## Backward Compatibility

No behavior change for code paths where `polygon_points` is already a Python list or `None`. The fix only adds correct handling for numpy arrays, which is what the layout detector actually produces.
