### PR TITLE
Add multipart/form-data and signed URL support to /glmocr/parse

### DIFF
--- a/glmocr/dataloader/page_loader.py
+++ b/glmocr/dataloader/page_loader.py
@@ -26,6 +26,8 @@ from glmocr.utils.image_utils import (
     load_image_to_base64,
     pdf_to_images_pil,
     pdf_to_images_pil_iter,
+    pdf_bytes_to_images_pil,
+    pdf_bytes_to_images_pil_iter,
     PYPDFIUM2_AVAILABLE,
 )
 from glmocr.utils.logging import get_logger, get_profiler
@@ -162,6 +164,11 @@ class PageLoader:
 
     def _iter_source(self, source: str):
         """Yield pages from a single source one at a time."""
+        if source.startswith("data:application/pdf;base64,"):
+            pdf_bytes = base64.b64decode(source.split(",", 1)[1])
+            yield from self._iter_pdf_bytes(pdf_bytes)
+            return
+
         if source.startswith("file://"):
             file_path = source[7:]
         else:
@@ -205,6 +212,10 @@ class PageLoader:
 
         PDFs return all pages; images return a single-page list.
         """
+        if source.startswith("data:application/pdf;base64,"):
+            pdf_bytes = base64.b64decode(source.split(",", 1)[1])
+            return self._load_pdf_bytes(pdf_bytes)
+
         if source.startswith("file://"):
             file_path = source[7:]
         else:
@@ -259,6 +270,42 @@ class PageLoader:
             (time.perf_counter() - t0) * 1000,
         )
         return pages
+
+    def _load_pdf_bytes(self, pdf_bytes: bytes) -> List[Image.Image]:
+        """Load all pages from in-memory PDF bytes using pypdfium2 (no disk I/O)."""
+        if not PYPDFIUM2_AVAILABLE:
+            raise RuntimeError(
+                "PDF support requires pypdfium2. Install: pip install pypdfium2"
+            )
+        t0 = time.perf_counter()
+        end_page = self._compute_end_page()
+        pages = pdf_bytes_to_images_pil(
+            pdf_bytes,
+            dpi=self.pdf_dpi,
+            max_width_or_height=3500,
+            start_page_id=0,
+            end_page_id=end_page,
+        )
+        profiler.log(
+            "pdf_bytes_to_images_pil(in-memory)",
+            (time.perf_counter() - t0) * 1000,
+        )
+        return pages
+
+    def _iter_pdf_bytes(self, pdf_bytes: bytes):
+        """Yield PDF pages one at a time from in-memory bytes (streaming, no disk I/O)."""
+        if not PYPDFIUM2_AVAILABLE:
+            raise RuntimeError(
+                "PDF support requires pypdfium2. Install: pip install pypdfium2"
+            )
+        end_page = self._compute_end_page()
+        yield from pdf_bytes_to_images_pil_iter(
+            pdf_bytes,
+            dpi=self.pdf_dpi,
+            max_width_or_height=3500,
+            start_page_id=0,
+            end_page_id=end_page,
+        )
 
     # =========================================================================
     # API request building

--- a/glmocr/server.py
+++ b/glmocr/server.py
@@ -1,10 +1,12 @@
 """GLM-OCR SDK Flask service."""
 
+import base64
 import os
 import sys
 import traceback
 import multiprocessing
-from typing import TYPE_CHECKING
+import urllib.request
+from typing import TYPE_CHECKING, List, Tuple
 
 try:
     from flask import Flask, request, jsonify
@@ -53,54 +55,134 @@ def create_app(config: "GlmOcrConfig") -> Flask:
     app.config["pipeline"] = pipeline
     app.config["doc_config"] = config
 
+    def _remote_url_to_data_uri(url: str) -> str:
+        """Fetch a remote URL and return a data: URI (no temp file)."""
+        req = urllib.request.Request(url, headers={"User-Agent": "glmocr/1.0"})
+        with urllib.request.urlopen(req, timeout=60) as resp:
+            content_type = resp.headers.get_content_type() or "application/octet-stream"
+            data = resp.read()
+        b64 = base64.b64encode(data).decode()
+        return f"data:{content_type};base64,{b64}"
+
+    def _file_bytes_to_data_uri(file_bytes: bytes, content_type: str, filename: str = "") -> str:
+        """Convert uploaded file bytes to a data: URI.
+
+        Detects PDFs by magic bytes so the page_loader can route them correctly.
+        """
+        # Detect PDF by magic bytes (%PDF) regardless of declared content_type
+        if file_bytes[:4] == b"%PDF" or "pdf" in content_type.lower():
+            mime = "application/pdf"
+        elif content_type and content_type.startswith("image/"):
+            mime = content_type
+        else:
+            # Fallback: guess from filename extension
+            import mimetypes
+
+            guessed, _ = mimetypes.guess_type(filename or "")
+            mime = guessed or "application/octet-stream"
+        b64 = base64.b64encode(file_bytes).decode()
+        return f"data:{mime};base64,{b64}"
+
+    def _resolve_urls(raw_urls: List[str]) -> List[str]:
+        """Convert http/https signed URLs to data: URIs; pass others through."""
+        resolved = []
+        for url in raw_urls:
+            if url.startswith(("http://", "https://")):
+                resolved.append(_remote_url_to_data_uri(url))
+            else:
+                resolved.append(url)
+        return resolved
+
     @app.route("/glmocr/parse", methods=["POST"])
     def parse():
         """Document parsing endpoint.
 
-        Request:
-            {
-                "images": ["url1", "url2", ...],  # image URLs (http/https/file/data)
-            }
+        Accepts three Content-Type variants:
+
+        1. application/json (original):
+            {"images": ["file://...", "data:...", "https://signed-url..."]}
+
+        2. multipart/form-data (file upload):
+            files=<file1>&files=<file2>&urls=https://...&urls=https://...
+            Field name "files" for uploaded files, "urls" for remote URLs.
+
+        3. Mixed multipart: both "files" and "urls" fields together.
+
+        Signed https:// URLs (in JSON or multipart) are fetched in-memory and
+        converted to data: URIs — no temp files are written.
 
         Response:
-            {
-                "json_result": {...},
-                "markdown_result": "..."
-            }
+            {"json_result": {...}, "markdown_result": "..."}
         """
-        # Validate Content-Type
-        if request.headers.get("Content-Type") != "application/json":
+        content_type = request.content_type or ""
+
+        if content_type.startswith("multipart/form-data"):
+            # --- multipart/form-data ---
+            image_urls: List[str] = []
+
+            # Uploaded files → in-memory data: URIs
+            for uploaded in request.files.getlist("files"):
+                file_bytes = uploaded.read()
+                if not file_bytes:
+                    continue
+                data_uri = _file_bytes_to_data_uri(
+                    file_bytes,
+                    uploaded.mimetype or "",
+                    uploaded.filename or "",
+                )
+                image_urls.append(data_uri)
+
+            # Remote URLs in the form (signed URLs or plain URLs)
+            for url in request.form.getlist("urls"):
+                url = url.strip()
+                if url:
+                    image_urls.append(url)
+
+            if not image_urls:
+                return jsonify({"error": "No files or urls provided"}), 400
+
+            # Resolve any http/https URLs to data: URIs
+            try:
+                image_urls = _resolve_urls(image_urls)
+            except Exception as e:
+                return jsonify({"error": f"Failed to fetch URL: {e}"}), 400
+
+        elif "application/json" in content_type:
+            # --- application/json ---
+            try:
+                data = request.get_json(force=True)
+            except Exception:
+                return jsonify({"error": "Invalid JSON payload"}), 400
+
+            images = data.get("images", [])
+            if isinstance(images, str):
+                images = [images]
+            if not images:
+                return jsonify({"error": "No images provided"}), 400
+
+            # Resolve signed http/https URLs to data: URIs
+            try:
+                image_urls = _resolve_urls(images)
+            except Exception as e:
+                return jsonify({"error": f"Failed to fetch URL: {e}"}), 400
+
+        else:
             return (
                 jsonify(
-                    {"error": "Invalid Content-Type. Expected 'application/json'."}
+                    {
+                        "error": "Unsupported Content-Type. Use application/json or multipart/form-data."
+                    }
                 ),
-                400,
+                415,
             )
 
-        # Parse JSON payload
-        try:
-            data = request.json
-        except Exception:
-            return jsonify({"error": "Invalid JSON payload"}), 400
-
-        images = data.get("images", [])
-        if isinstance(images, str):
-            images = [images]
-
-        if not images:
-            return jsonify({"error": "No images provided"}), 400
-
-        # Build pipeline request
+        # Build pipeline request_data
         messages = [{"role": "user", "content": []}]
-        for image_url in images:
-            messages[0]["content"].append(
-                {"type": "image_url", "image_url": {"url": image_url}}
-            )
-
+        for url in image_urls:
+            messages[0]["content"].append({"type": "image_url", "image_url": {"url": url}})
         request_data = {"messages": messages}
 
         try:
-            # Pipeline.process() yields one result per input unit; merge for single response
             results = list(
                 pipeline.process(
                     request_data,
@@ -109,10 +191,7 @@ def create_app(config: "GlmOcrConfig") -> Flask:
                 )
             )
             if not results:
-                return (
-                    jsonify({"json_result": None, "markdown_result": ""}),
-                    200,
-                )
+                return jsonify({"json_result": None, "markdown_result": ""}), 200
             if len(results) == 1:
                 r = results[0]
                 return (
@@ -124,18 +203,11 @@ def create_app(config: "GlmOcrConfig") -> Flask:
                     ),
                     200,
                 )
-            # Multiple units: merge json as list, markdown with separator
+            # Multiple units: list of json_results, markdown separated by ---
             json_result = [r.json_result for r in results]
-            markdown_result = "\n\n---\n\n".join(
-                r.markdown_result or "" for r in results
-            )
+            markdown_result = "\n\n---\n\n".join(r.markdown_result or "" for r in results)
             return (
-                jsonify(
-                    {
-                        "json_result": json_result,
-                        "markdown_result": markdown_result,
-                    }
-                ),
+                jsonify({"json_result": json_result, "markdown_result": markdown_result}),
                 200,
             )
 
@@ -190,9 +262,7 @@ def main():
         server_config = config.server
         logger.info("")
         logger.info("=" * 60)
-        logger.info(
-            "GlmOcr Server starting on %s:%d...", server_config.host, server_config.port
-        )
+        logger.info("GlmOcr Server starting on %s:%d...", server_config.host, server_config.port)
         logger.info("API endpoint: /glmocr/parse")
         logger.info("=" * 60)
         logger.info("")

--- a/glmocr/utils/image_utils.py
+++ b/glmocr/utils/image_utils.py
@@ -286,6 +286,102 @@ def _page_to_image(page, dpi: int = 200, max_width_or_height: int = 3500):
     return image, scale
 
 
+def pdf_bytes_to_images_pil(
+    pdf_bytes: bytes,
+    dpi: int = 200,
+    max_width_or_height: int = 3500,
+    start_page_id: int = 0,
+    end_page_id: int = None,
+) -> list:
+    """Convert in-memory PDF bytes to list of PIL Images using pypdfium2.
+
+    Args:
+        pdf_bytes: Raw PDF bytes.
+        dpi: Render DPI.
+        max_width_or_height: Max width or height.
+        start_page_id: Start page index (0-based).
+        end_page_id: End page index (inclusive); None = last page.
+
+    Returns:
+        List of PIL.Image.
+    """
+    if not PYPDFIUM2_AVAILABLE:
+        raise ImportError(
+            "PDF support requires pypdfium2. Install with: pip install pypdfium2"
+        )
+    import pypdfium2 as pdfium
+
+    pdf = None
+    try:
+        pdf = pdfium.PdfDocument(pdf_bytes)
+        page_count = len(pdf)
+        if end_page_id is None or end_page_id < 0:
+            end_page_id = page_count - 1
+        if end_page_id >= page_count:
+            end_page_id = page_count - 1
+        images = []
+        for i in range(start_page_id, end_page_id + 1):
+            page = pdf[i]
+            try:
+                image, _ = _page_to_image(
+                    page, dpi=dpi, max_width_or_height=max_width_or_height
+                )
+                images.append(image)
+            finally:
+                page.close()
+        return images
+    finally:
+        if pdf is not None:
+            pdf.close()
+
+
+def pdf_bytes_to_images_pil_iter(
+    pdf_bytes: bytes,
+    dpi: int = 200,
+    max_width_or_height: int = 3500,
+    start_page_id: int = 0,
+    end_page_id: int = None,
+):
+    """Convert in-memory PDF bytes to PIL Images one page at a time (generator).
+
+    Args:
+        pdf_bytes: Raw PDF bytes.
+        dpi: Render DPI.
+        max_width_or_height: Max width or height.
+        start_page_id: Start page index (0-based).
+        end_page_id: End page index (inclusive); None = last page.
+
+    Yields:
+        PIL.Image per page.
+    """
+    if not PYPDFIUM2_AVAILABLE:
+        raise ImportError(
+            "PDF support requires pypdfium2. Install with: pip install pypdfium2"
+        )
+    import pypdfium2 as pdfium
+
+    pdf = None
+    try:
+        pdf = pdfium.PdfDocument(pdf_bytes)
+        page_count = len(pdf)
+        if end_page_id is None or end_page_id < 0:
+            end_page_id = page_count - 1
+        if end_page_id >= page_count:
+            end_page_id = page_count - 1
+        for i in range(start_page_id, end_page_id + 1):
+            page = pdf[i]
+            try:
+                image, _ = _page_to_image(
+                    page, dpi=dpi, max_width_or_height=max_width_or_height
+                )
+                yield image
+            finally:
+                page.close()
+    finally:
+        if pdf is not None:
+            pdf.close()
+
+
 def pdf_to_images_pil(
     pdf_path: str,
     dpi: int = 200,


### PR DESCRIPTION
## Summary

- **`server.py`**: `/glmocr/parse` now accepts `multipart/form-data` (uploaded files via `files` field, remote URLs via `urls` field) and `http/https` signed URLs in JSON mode; all inputs are converted to `data:` URIs in-memory — no temp files written
- **`image_utils.py`**: added `pdf_bytes_to_images_pil` and `pdf_bytes_to_images_pil_iter` for zero-disk-I/O PDF rendering via pypdfium2 in-memory bytes API
- **`page_loader.py`**: added `data:application/pdf;base64,...` routing in `_load_source` / `_iter_source`; added `_load_pdf_bytes` and `_iter_pdf_bytes` methods

## Usage

**File upload (multipart):**
```bash
curl -X POST http://localhost:5002/glmocr/parse \
  -F "files=@document.pdf" \
  -F "files=@image.png"
```

**Signed URL (JSON):**
```bash
curl -X POST http://localhost:5002/glmocr/parse \
  -H "Content-Type: application/json" \
  -d '{"images": ["https://s3.amazonaws.com/bucket/doc.pdf?X-Amz-Signature=..."]}'
```

**Mixed (multipart + remote URLs):**
```bash
curl -X POST http://localhost:5002/glmocr/parse \
  -F "files=@local.pdf" \
  -F "urls=https://signed-url/remote.png"
```

## Test plan

- [ ] Upload a PDF via multipart — verify all pages rendered correctly
- [ ] Upload an image via multipart — verify result matches JSON path
- [ ] Pass a signed S3/GCS URL in JSON `images` — verify fetched in-memory
- [ ] Pass a signed URL in multipart `urls` field — verify resolved correctly
- [ ] Existing `application/json` with `file://` and `data:` URLs still works
- [ ] Invalid Content-Type returns 415

🤖 Generated with [Claude Code](https://claude.com/claude-code)