### PR TITLE
feat(examples): add progress feedback for batch parsing

### DIFF
--- a/examples/example.py
+++ b/examples/example.py
@@ -7,9 +7,32 @@ examples/result/ (one folder per input file).
 from __future__ import annotations
 
 import shutil
+import subprocess
 from pathlib import Path
 
 from glmocr.api import GlmOcr
+
+try:
+    from tqdm.auto import tqdm
+except Exception:
+    tqdm = None
+
+
+def _get_pdf_pages(pdf_path: Path) -> int:
+    """Best-effort page count for local PDFs via pdfinfo."""
+    try:
+        output = subprocess.check_output(
+            ["pdfinfo", str(pdf_path)],
+            text=True,
+            stderr=subprocess.DEVNULL,
+        )
+        for line in output.splitlines():
+            if line.lower().startswith("pages:"):
+                pages = int(line.split(":", 1)[1].strip())
+                return max(1, pages)
+    except Exception:
+        pass
+    return 1
 
 
 def main() -> int:
@@ -45,16 +68,29 @@ def main() -> int:
         )
 
     total = len(inputs)
+    work_units = [
+        _get_pdf_pages(p) if p.suffix.lower() == ".pdf" and poppler_ok else 1
+        for p in inputs
+    ]
+    total_units = sum(work_units)
     processed = 0
     skipped = 0
     failed = 0
+    progress = (
+        tqdm(total=total_units, desc="Parsing requests", unit="page")
+        if tqdm is not None and total_units > 1
+        else None
+    )
 
     with GlmOcr() as parser:
         for idx, p in enumerate(inputs, start=1):
-            print(f"\n[{idx}/{total}] Parsing: {p.name}")
+            unit_count = work_units[idx - 1]
+            print(f"\n[{idx}/{total}] Parsing: {p.name} ({unit_count} page(s))")
             if p.suffix.lower() == ".pdf" and not poppler_ok:
                 print(f"[{idx}/{total}] Skipping PDF (missing poppler)")
                 skipped += 1
+                if progress is not None:
+                    progress.update(unit_count)
                 continue
 
             try:
@@ -65,7 +101,12 @@ def main() -> int:
             except Exception as e:
                 failed += 1
                 print(f"[{idx}/{total}] Failed: {p.name}: {e}")
-                continue
+            finally:
+                if progress is not None:
+                    progress.update(unit_count)
+
+    if progress is not None:
+        progress.close()
 
     print(f"\nAll done. processed={processed}, skipped={skipped}, failed={failed}, total={total}")
     return 0

--- a/examples/example.py
+++ b/examples/example.py
@@ -44,21 +44,30 @@ def main() -> int:
             "PDF inputs will be skipped. On macOS: brew install poppler"
         )
 
+    total = len(inputs)
+    processed = 0
+    skipped = 0
+    failed = 0
+
     with GlmOcr() as parser:
-        for p in inputs:
-            print(f"\n=== Parsing: {p.name} ===")
+        for idx, p in enumerate(inputs, start=1):
+            print(f"\n[{idx}/{total}] Parsing: {p.name}")
             if p.suffix.lower() == ".pdf" and not poppler_ok:
-                print("Skipping PDF (missing poppler)")
+                print(f"[{idx}/{total}] Skipping PDF (missing poppler)")
+                skipped += 1
                 continue
 
             try:
                 result = parser.parse(str(p))
                 result.save(output_dir=output_dir)
+                processed += 1
+                print(f"[{idx}/{total}] Done: {p.name}")
             except Exception as e:
-                print(f"Failed: {p.name}: {e}")
+                failed += 1
+                print(f"[{idx}/{total}] Failed: {p.name}: {e}")
                 continue
 
-    print("\nAll done.")
+    print(f"\nAll done. processed={processed}, skipped={skipped}, failed={failed}, total={total}")
     return 0
 
 


### PR DESCRIPTION
## Summary
- add explicit per-file progress output in `examples/example.py` (`[idx/total]` format)
- print a final summary with processed/skipped/failed/total counters
- keep behavior unchanged aside from user feedback

## Why
Issue #136 asks for feedback while processing PDF/document batches. This improves visibility during long runs without changing API behavior.

Closes #136
