### PR TITLE
docs: clarify GLM-OCR and PP-DocLayoutV3 in FAQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,17 @@ class MyPipeline:
     pass
 ```
 
+## FAQ
+
+### Is this project GLM-OCR or PP-DocLayoutV3?
+
+Both are used in the full pipeline, but they serve different roles:
+
+- `GLM-OCR` is the core multimodal OCR model used for recognition and structured output.
+- `PP-DocLayoutV3` is used for document layout detection (region segmentation) before OCR.
+
+In short: `PP-DocLayoutV3` is a layout component integrated into the `GLM-OCR` pipeline, not a replacement for GLM-OCR.
+
 ## Star History
 
 <a href="https://www.star-history.com/?repos=zai-org%2FGLM-OCR&type=date&legend=top-left">

--- a/README_zh.md
+++ b/README_zh.md
@@ -309,6 +309,17 @@ class MyPipeline:
     pass
 ```
 
+## FAQ
+
+### 这个项目到底是 GLM-OCR 还是 PP-DocLayoutV3？
+
+完整 pipeline 同时使用两者，但职责不同：
+
+- `GLM-OCR` 是核心多模态 OCR 模型，负责识别与结构化输出。
+- `PP-DocLayoutV3` 用于文档版面分析（区域检测），在 OCR 前完成页面分区。
+
+简而言之：`PP-DocLayoutV3` 是 `GLM-OCR` pipeline 中的版面组件，不是 GLM-OCR 的替代品。
+
 ## Star History
 
 <a href="https://www.star-history.com/?repos=zai-org%2FGLM-OCR&type=date&legend=top-left">


### PR DESCRIPTION
## Summary
- add an FAQ entry in English and Chinese README clarifying the roles of GLM-OCR and PP-DocLayoutV3
- explain that PP-DocLayoutV3 is the layout-analysis component in the pipeline, while GLM-OCR is the core recognition model

## Why
This addresses recurring confusion in issue #178 and reduces onboarding friction for new users.

Closes #178
