### PR TITLE
docs: clarify where text and image assets are saved

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,14 @@ result = parse(["img1.png", "img2.jpg"])
 result = parse("https://example.com/image.png")
 result.save(output_dir="./results")
 
+# Typical output layout:
+# results/
+#   image/
+#     image.json          # structured OCR result
+#     image.md            # markdown result
+#     image_model.json    # raw model output (when available)
+#     imgs/               # extracted/cropped image regions (when available)
+
 # Note: a list is treated as pages of a single document.
 
 # Class-based API

--- a/README_zh.md
+++ b/README_zh.md
@@ -235,6 +235,14 @@ result = parse(["img1.png", "img2.jpg"])
 result = parse("https://example.com/image.png")
 result.save(output_dir="./results")
 
+# 典型输出目录结构：
+# results/
+#   image/
+#     image.json          # 结构化 OCR 结果
+#     image.md            # markdown 结果
+#     image_model.json    # 模型原始输出（可用时）
+#     imgs/               # 提取/裁剪得到的图片区域（可用时）
+
 # 说明：传入 list 会被当作同一文档的多页
 
 # 类接口


### PR DESCRIPTION
## Summary
- document the output directory layout produced by `result.save(output_dir=...)`
- clarify where structured text (`*.json`, `*.md`) and extracted image assets (`imgs/`) are written
- add the same guidance to both English and Chinese README

## Why
Issue #187 asks how to extract text and images from parsed pages. This adds explicit, copy-paste-friendly guidance in the quickstart section.

Closes #187
