### PR TITLE
Allow layout on CPU even if valid cuda GPU exists

### DIFF
--- a/glmocr/layout/layout_detector.py
+++ b/glmocr/layout/layout_detector.py
@@ -88,7 +88,7 @@ class PPDocLayoutDetector(BaseLayoutDetector):
         #   2. Auto: cuda:{cuda_visible_devices} if CUDA available, else CPU
         if self._config_device is not None:
             self._device = self._config_device
-        elif torch.cuda.is_available() and self.cuda_visible_devices:
+        elif torch.cuda.is_available() and self.cuda_visible_devices and self.cuda_visible_devices != "cpu":
             self._device = f"cuda:{self.cuda_visible_devices}"
         else:
             self._device = "cpu"


### PR DESCRIPTION
If there is a valid cuda gpu and you had set `cuda_visible_devices`, previously it would error out trying to put the model on `cuda:cpu`. This is now fixed where if you set `cuda_visible_devices` to `cpu` it correctly loads the model onto the cpu :)