### PR TITLE
fix(ocr_client): default to 'Text Recognition:' prompt in ollama_generate mode

### DIFF
--- a/glmocr/ocr_client.py
+++ b/glmocr/ocr_client.py
@@ -468,9 +468,12 @@ class OCRClient:
                             images.append(image_url)
 
         # Build Ollama generate request
+        # Default to "Text Recognition:" when prompt is empty because Ollama
+        # requires a non-empty prompt to trigger the model. This matches the
+        # official documented usage for GLM-OCR on Ollama.
         ollama_request = {
             "model": self.model or "glm-ocr:latest",
-            "prompt": prompt,
+            "prompt": prompt if prompt else "Text Recognition:",
             "stream": False,
         }
 

--- a/glmocr/tests/test_unit.py
+++ b/glmocr/tests/test_unit.py
@@ -1682,14 +1682,14 @@ class TestConvertToOllamaGenerate:
         """Handles empty messages list."""
         client = self._make_client()
         result = client._convert_to_ollama_generate({"messages": []})
-        assert result["prompt"] == ""
+        assert result["prompt"] == "Text Recognition:"
         assert "images" not in result
 
     def test_no_messages_key(self):
         """Handles missing messages key."""
         client = self._make_client()
         result = client._convert_to_ollama_generate({})
-        assert result["prompt"] == ""
+        assert result["prompt"] == "Text Recognition:"
 
     def test_non_user_messages_ignored(self):
         """System and assistant messages are ignored (last user message used)."""


### PR DESCRIPTION
## Problem
When using `api_mode: ollama_generate`, the SDK sends requests to Ollama 
with an empty prompt. Ollama requires a non-empty prompt to trigger the 
model — without it, the model returns empty content and `json_result` is `[[]]`.

## Root Cause
The SDK builds the prompt from message content, but GLM-OCR's internal 
pipeline sends image-only requests with no text. This works against the 
native GLM-OCR API but Ollama silently ignores empty prompts.

## Fix
Default to `"Text Recognition:"` when the prompt is empty, matching 
Ollama's official documented usage for GLM-OCR.

Note: any non-empty prompt works (even "."), but `"Text Recognition:"` 
is used as it matches the official Ollama docs for this model.

Fixes #207