### PR TITLE
Doc Fix: require transformers>=5.3.1 for PP-DocLayoutV3 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ pip install -U "vllm>=0.19.0"
 Launch the service:
 
 ```bash
-pip install "transformers>=5.3.0"
+pip install "transformers>=5.3.1"
 
 vllm serve zai-org/GLM-OCR  --port 8080 --speculative-config '{"method": "mtp", "num_speculative_tokens": 3}' --served-model-name glm-ocr
 ```

--- a/README_zh.md
+++ b/README_zh.md
@@ -124,7 +124,7 @@ pip install -U "vllm>=0.19.0"
 启动服务：
 
 ```bash
-pip install "transformers>=5.3.0"
+pip install "transformers>=5.3.1"
 
 vllm serve zai-org/GLM-OCR  --port 8080 --speculative-config '{"method": "mtp", "num_speculative_tokens": 3}' --served-model-name glm-ocr
 ```


### PR DESCRIPTION
The `PPDocLayoutV3ForObjectDetection` and `PPDocLayoutV3ImageProcessor` classes are only available in transformers 5.3.1+. Update version constraint to ensure compatibility.

in transformers 5.3.0 
https://github.com/zai-org/GLM-OCR/blob/v0.1.5/glmocr/layout/layout_detector.py#L11-L14
```text
ImportError: cannot import name 'PPDocLayoutV3ImageProcessor' from 'transformers'
```

Changes:
- README.md: transformers>=5.3.0 → transformers>=5.3.1
- README_zh.md: transformers>=5.3.0 → transformers>=5.3.1

# Contribution Guide

We welcome your contributions to this repository. To ensure elegant code style and better code quality, we have prepared
the following contribution guidelines.

## What We Accept

+ This PR fixes a typo or improves the documentation (if this is the case, you may skip the other checks).
+ This PR fixes a specific issue — please reference the issue number in the PR description. Make sure your code strictly
  follows the coding standards below.
+ This PR introduces a new feature — please clearly explain the necessity and implementation of the feature. Make sure
  your code strictly follows the coding standards below.

## Code Style Guide

Good code style is an art. We have prepared a `pre-commit` hook to enforce consistent code
formatting across the project. You can clean up your code following the steps below:

```shell
pre-commit run --all-files
```

If your code complies with the standards, you should not see any errors.

## Naming Conventions

+ Please use **English** for naming; do not use Pinyin or other languages. All comments should also be in English.
+ Follow **PEP8** naming conventions strictly, and use underscores to separate words. Avoid meaningless names such as
  `a`, `b`, `c`.
