### PR TITLE
fix: convert RGBA to RGB before saving as JPEG

### DIFF
--- a/glmocr/parser_result/base.py
+++ b/glmocr/parser_result/base.py
@@ -118,7 +118,8 @@ class BaseParserResult(ABC):
             imgs_dir.mkdir(parents=True, exist_ok=True)
             for filename, img in self.image_files.items():
                 try:
-                    img.save(imgs_dir / filename, quality=95)
+                    save_img = img.convert("RGB") if img.mode == "RGBA" else img
+                    save_img.save(imgs_dir / filename, quality=95)
                 except Exception as e:
                     logger.warning("Failed to save image %s: %s", filename, e)
             self.image_files = None


### PR DESCRIPTION
## Summary

Fix `cannot write mode RGBA as JPEG` error when saving cropped image regions from PNG sources with alpha channel.

Convert RGBA PIL images to RGB before saving as JPEG in `BaseParserResult._save_json_and_markdown()`.

## Why

When the source image is a PNG with an alpha channel (RGBA mode), cropped regions retain the RGBA mode through the pipeline:

1. `crop_image_region()` in `image_utils.py` crops from the original image, preserving RGBA mode
2. `ResultFormatter.process()` in `result_formatter.py` assigns hardcoded `.jpg` filenames to these cropped images
3. `BaseParserResult._save_json_and_markdown()` in `base.py` calls `img.save()` on RGBA images with a `.jpg` path — PIL cannot write RGBA as JPEG, raising `OSError: cannot write mode RGBA as JPEG`

The RGBA-to-RGB conversion discards the alpha channel, which is acceptable because JPEG does not support transparency anyway. The white background from `convert("RGB")` is a reasonable default.

## Validation

- [x] Tested with `glmocr parse ./test.png --config ./config.yaml` using a PNG input with alpha channel — all 5 cropped images saved successfully without errors
- [x] Output files confirmed in `output/test/imgs/` directory

## Scope

This PR intentionally keeps the fix narrow:

- only adds a one-line RGBA→RGB conversion at the save point in `base.py`
- no changes to filename generation logic (`.jpg` hardcoded in `result_formatter.py` and `markdown_utils.py`)
- no changes to image loading or cropping pipeline

Those can be handled separately if needed.