### PR TITLE
fix(tasks): prevent path traversal in /tasks/file endpoint

### DIFF
--- a/apps/backend/app/api/tasks.py
+++ b/apps/backend/app/api/tasks.py
@@ -113,6 +113,16 @@ async def read_file(path: str):
     try:
         file_path = Path(path)
 
+        # Prevent path traversal: resolve and check within allowed directory
+        allowed_dir = Path(settings.OUTPUT_DIR).resolve()
+        resolved_path = file_path.resolve()
+        if not str(resolved_path).startswith(str(allowed_dir) + "/") and resolved_path != allowed_dir:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Access denied: path is outside the allowed directory",
+            )
+        file_path = resolved_path
+
         # 检查文件是否存在
         if not file_path.exists():
             raise HTTPException(


### PR DESCRIPTION
## Vulnerability Summary

The `GET /api/v1/tasks/file` endpoint in `apps/backend/app/api/tasks.py` accepts an arbitrary file path via the `path` query parameter and returns the file's contents with no restriction on which files can be read. There is no authentication on this endpoint (the `tasks` router has no `dependencies` parameter), and CORS is configured with `allow_origins=["*"]`, meaning any origin can make requests.

This is a **CWE-22 (Path Traversal)** vulnerability that allows any network-accessible attacker to read arbitrary files from the server filesystem — including `/etc/passwd`, `/etc/shadow` (if permissions allow), environment files, application secrets, and any other file readable by the application process.

**Affected function:** `read_file()` at `apps/backend/app/api/tasks.py:104`

**Data flow:** The `path` query parameter is passed directly to `Path(path)`, and the resulting path is used to open and return the file without any validation that it resides within the intended output directory.

## Proof of Concept

With the server running (default `./data` as `OUTPUT_DIR`):

```bash
# Read /etc/passwd via path traversal
curl "http://localhost:8000/api/v1/tasks/file?path=../../../etc/passwd"

# Or using an absolute path directly
curl "http://localhost:8000/api/v1/tasks/file?path=/etc/passwd"
```

Both requests return the contents of `/etc/passwd`. The endpoint was designed to serve task output files from `OUTPUT_DIR` (`./data` by default), but accepts any path on the filesystem.

## Fix Description

This PR adds a path traversal guard before the file is read. The fix:

1. Resolves `settings.OUTPUT_DIR` to an absolute path (`allowed_dir`)
2. Resolves the user-supplied `path` to an absolute path (`resolved_path`)
3. Checks that `resolved_path` starts with `allowed_dir + "/"` (or equals `allowed_dir` itself)
4. Returns HTTP 403 if the resolved path falls outside the allowed directory

This is the standard canonicalize-then-compare approach recommended for path traversal prevention. Using `Path.resolve()` eliminates `../`, symlink tricks, and other bypass techniques before the comparison.

## Testing

We verified the fix by confirming:
- Traversal attempts like `?path=../../../etc/passwd` and `?path=/etc/passwd` are rejected with 403
- Legitimate paths within `OUTPUT_DIR` (e.g., `?path=./data/some-task/output.json`) continue to work
- The `startswith` check uses `str(allowed_dir) + "/"` to prevent prefix confusion (e.g., `/data2/evil` does not match `/data`)

## Adversarial Review

Before submitting, we considered whether any existing protections mitigate this. They don't — the `tasks` router (`APIRouter(prefix="/tasks", tags=["tasks"])`) has no `dependencies` parameter injecting authentication, no middleware checks auth for this route, and CORS is wide open (`allow_origins=["*"]`). The endpoint is fully unauthenticated and directly reachable. The only precondition is network access to the server.