### PR TITLE
fix(page_loader): handle data:application/pdf;base64 data URIs

### DIFF
--- a/glmocr/dataloader/page_loader.py
+++ b/glmocr/dataloader/page_loader.py
@@ -9,6 +9,7 @@ Supported inputs:
 - Local file paths (images, PDFs)
 - file:// URLs
 - data:image/... base64 URLs
+- data:application/pdf;base64,... data URIs
 """
 
 from __future__ import annotations
@@ -173,6 +174,12 @@ class PageLoader:
                 yield Image.open(BytesIO(source))
             return
 
+        # data:application/pdf;base64,... data URI
+        if source.startswith("data:application/pdf"):
+            _, b64_data = source.split(",", 1)
+            yield from self._iter_pdf_bytes(base64.b64decode(b64_data))
+            return
+
         if source.startswith("file://"):
             file_path = source[7:]
         else:
@@ -245,6 +252,11 @@ class PageLoader:
             if source[:5] == b"%PDF-":
                 return self._load_pdf_bytes(source)
             return [Image.open(BytesIO(source))]
+
+        # data:application/pdf;base64,... data URI
+        if source.startswith("data:application/pdf"):
+            _, b64_data = source.split(",", 1)
+            return self._load_pdf_bytes(base64.b64decode(b64_data))
 
         if source.startswith("file://"):
             file_path = source[7:]


### PR DESCRIPTION
## Summary

Fixes #211 — when the MaaS client sends a PDF as a `data:application/pdf;base64,...` data URI to a self-hosted SDK server, the server raises:

```
Error loading image 'data:application/pdf;base64,...': Invalid image source
```

The root cause is that both `_load_source` and `_iter_source` only recognised PDFs from:
- raw `bytes` starting with `%PDF-`
- local file paths ending in `.pdf`

`data:application/pdf;base64,...` strings fell through to `_load_image`, which only handles `data:image/...` and raised `ValueError("Invalid image source")`.

## Fix

Added a `data:application/pdf` prefix check in both `_load_source` (batch mode) and `_iter_source` (streaming mode), decoding the base64 payload and routing it to the existing `_load_pdf_bytes` / `_iter_pdf_bytes` helpers — the same path already used for raw PDF bytes.

```python
# data:application/pdf;base64,... data URI
if source.startswith("data:application/pdf"):
    _, b64_data = source.split(",", 1)
    return self._load_pdf_bytes(base64.b64decode(b64_data))
```

## Test plan

- [ ] Send a PDF via the self-hosted server using the SDK client (`maas.enabled: true`, `api_url` pointing at the server) — previously returned empty results, now processes all pages correctly
- [ ] Send a PNG via the same path — still works (unaffected code path)
- [ ] Send a raw PDF `bytes` object — still works (unaffected code path)
- [ ] `pre-commit run --files glmocr/dataloader/page_loader.py` passes (black, flake8, typos — all clean)