### PR TITLE
docs: fix README H1 heading and capitalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## GLM-OCR
+# GLM-OCR
 
 [中文阅读](README_zh.md)
 
@@ -131,7 +131,7 @@ vllm serve zai-org/GLM-OCR  --port 8080 --speculative-config '{"method": "mtp", 
 ```
 
 >Note
-  Add `--max-model-len` and `--gpu-memory-utilization` according to Your own machine to handle large image/pdf
+  Add `--max-model-len` and `--gpu-memory-utilization` according to your own machine to handle large images/PDFs
 
 ##### Using SGLang
 
@@ -154,7 +154,7 @@ SGLANG_ENABLE_SPEC_V2=1 sglang serve --model-path zai-org/GLM-OCR --port 8080 --
 ```
 
 >Note
-  Add `--context-len` and `--mem-fraction-static` according to Your own machine to handle large image/pdf
+  Add `--context-len` and `--mem-fraction-static` according to your own machine to handle large images/PDFs
 
 
 #### Option 3: Ollama/MLX


### PR DESCRIPTION
Three small README fixes:

1. **Heading level** — the README starts with `## GLM-OCR` (H2). Every other zai-org README starts with `#` (H1), and the H2 here breaks GitHub's automatic title anchor / TOC rendering. Promoted to `# GLM-OCR`.
2. **Capitalization** — two instances of "according to Your own machine" with stray capital Y mid-sentence; lowercased to "your own machine".
3. `image/pdf` → `images/PDFs` (plural + acronym caps), in the same two notes.