### PR TITLE
fix(api): confine /tasks/file reads to OUTPUT_DIR (path traversal)

### DIFF
--- a/apps/backend/app/api/tasks.py
+++ b/apps/backend/app/api/tasks.py
@@ -118,7 +118,13 @@ async def read_file(path: str):
         # readable by the service.
         base_dir = Path(settings.OUTPUT_DIR).resolve()
         try:
-            file_path = Path(path).resolve()
+            requested = Path(path)
+            # Interpret relative paths under OUTPUT_DIR (not the process CWD),
+            # so a relative request keeps its intended OUTPUT_DIR-relative
+            # meaning instead of being rejected.
+            if not requested.is_absolute():
+                requested = base_dir / requested
+            file_path = requested.resolve()
         except (OSError, ValueError, RuntimeError):
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,

--- a/apps/backend/app/api/tasks.py
+++ b/apps/backend/app/api/tasks.py
@@ -111,7 +111,24 @@ async def read_file(path: str):
     - **path**: 文件路径
     """
     try:
-        file_path = Path(path)
+        # Confine reads to the configured output directory. Resolve the
+        # requested path (collapsing any "../" traversal and symlinks) and
+        # require it to live under OUTPUT_DIR; otherwise an arbitrary `path`
+        # (e.g. "/etc/passwd") would be read and returned, exposing any file
+        # readable by the service.
+        base_dir = Path(settings.OUTPUT_DIR).resolve()
+        try:
+            file_path = Path(path).resolve()
+        except (OSError, ValueError, RuntimeError):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Invalid path",
+            )
+        if not file_path.is_relative_to(base_dir):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Access denied: path is outside the allowed directory",
+            )
 
         # 检查文件是否存在
         if not file_path.exists():


### PR DESCRIPTION
## Problem (arbitrary file read / path traversal)

`GET /api/v1/tasks/file` (`read_file` in `apps/backend/app/api/tasks.py`) returns the contents of **any** path the client supplies, after checking only that it exists and is a file:

```python
@router.get("/file")
async def read_file(path: str):
    ...
    file_path = Path(path)
    if not file_path.exists(): ...404
    if not file_path.is_file(): ...400
    with open(file_path, "rb") as f:
        content = f.read()        # served back (image bytes, or JSON text for other types)
```

There is no confinement to an allowed directory, so the endpoint reads and returns any file the service process can access:

```
GET /api/v1/tasks/file?path=/etc/passwd
GET /api/v1/tasks/file?path=C:\Windows\win.ini
GET /api/v1/tasks/file?path=../../some/other/file
```

For a self-hostable service this is an arbitrary file read — config files, source, SQLite DB, keys, etc. become readable by anyone who can reach the API.

## Fix

Confine reads to `settings.OUTPUT_DIR`, which is the only location this app writes the files this endpoint is meant to serve:
- uploads default to `OUTPUT_DIR` (`upload_file_manager.save_to_path`),
- task artifacts (the OCR result images/markdown referenced via this endpoint) live in `OUTPUT_DIR/<task_id>/` (`pipeline_flow`).

The requested path is resolved (collapsing `../` and symlinks) and required to be under `OUTPUT_DIR`; otherwise it returns `403`.

## Validation

Verified the confinement decision against the real serving logic:

| request | before (`exists && is_file`) | after (confined to OUTPUT_DIR) |
|---|---|---|
| legit file under `OUTPUT_DIR/<task_id>/img.png` | served ✅ | served ✅ |
| `?path=<file outside OUTPUT_DIR>` | **served** ❌ | 403 ✅ |
| `?path=<OUTPUT_DIR>/../../secret` (traversal) | served/blocked inconsistently | 403 ✅ |
| `?path=/etc/hostname` (or `C:\Windows\win.ini`) | **served** ❌ | 403 ✅ |

Legitimate use (the markdown image URLs this endpoint backs) is unchanged; only out-of-tree paths are rejected.
